### PR TITLE
Speed limiter fix. Object passthrough fix. Ground rotation limiter implemented. 

### DIFF
--- a/Assets/_Prefabs/Butterflyv03.prefab
+++ b/Assets/_Prefabs/Butterflyv03.prefab
@@ -1470,7 +1470,7 @@ MonoBehaviour:
   sendTriggerMessage: 0
   layerMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 8192
   skinWidth: 1
 --- !u!114 &114513134657043068
 MonoBehaviour:
@@ -1507,13 +1507,6 @@ MonoBehaviour:
   movementXSpeed: 0
   movementYSpeed: 0
   movementZSpeed: 0
-  bias: 0.85
-  followDistance: 10
-  followHeight: 2
-  cameraVertOffsetMax: 10
-  cameraVertOffsetMin: 5
-  cameraFollowOffsetMax: 40
-  cameraFollowOffsetMin: 20
   killCount: 0
   killMsgActive: 0
   killTime: 0

--- a/Assets/_Prefabs/Butterflyv03.prefab
+++ b/Assets/_Prefabs/Butterflyv03.prefab
@@ -1471,7 +1471,7 @@ MonoBehaviour:
   layerMask:
     serializedVersion: 2
     m_Bits: 8192
-  skinWidth: 1
+  skinWidth: 0.1
 --- !u!114 &114513134657043068
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/_Prefabs/Knife.prefab
+++ b/Assets/_Prefabs/Knife.prefab
@@ -214,7 +214,7 @@ Rigidbody:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1159124314516858}
   serializedVersion: 2
-  m_Mass: 1
+  m_Mass: 50
   m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1

--- a/Assets/_Prefabs/Main Camera.prefab
+++ b/Assets/_Prefabs/Main Camera.prefab
@@ -204,7 +204,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_TrackedObjectOffset: {x: 0, y: 0, z: 100}
+  m_TrackedObjectOffset: {x: 0, y: 3, z: 100}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 10
   m_HorizontalDamping: 0.5
@@ -259,7 +259,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_BindingMode: 3
-  m_FollowOffset: {x: 0, y: 3, z: -20}
+  m_FollowOffset: {x: 0, y: 5, z: -20}
   m_XDamping: 1
   m_YDamping: 1
   m_ZDamping: 1

--- a/Assets/_Scenes/BKFstage.unity
+++ b/Assets/_Scenes/BKFstage.unity
@@ -498,7 +498,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 36335037}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicTable (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -995,7 +995,7 @@ GameObject:
   - component: {fileID: 134863389}
   - component: {fileID: 134863388}
   - component: {fileID: 134863387}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: SandboxBottom
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2019,7 +2019,7 @@ GameObject:
   - component: {fileID: 352763167}
   - component: {fileID: 352763166}
   - component: {fileID: 352763165}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2806,6 +2806,10 @@ Prefab:
       propertyPath: m_Name
       value: Tree (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 1605301185876994, guid: 5cff69b3316174a9eb19d976d6179107, type: 2}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 5cff69b3316174a9eb19d976d6179107, type: 2}
   m_IsPrefabParent: 0
@@ -3243,7 +3247,7 @@ GameObject:
   - component: {fileID: 529577191}
   - component: {fileID: 529577190}
   - component: {fileID: 529577189}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3470,6 +3474,10 @@ Prefab:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: cb29bea6bc07a4758a457773022a511c, type: 2}
+    - target: {fileID: 1474198792300102, guid: ab395fc603590412fb82c8b7d65d671f, type: 2}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: ab395fc603590412fb82c8b7d65d671f, type: 2}
   m_IsPrefabParent: 0
@@ -3625,7 +3633,7 @@ GameObject:
   - component: {fileID: 637257903}
   - component: {fileID: 637257902}
   - component: {fileID: 637257901}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3767,7 +3775,7 @@ GameObject:
   - component: {fileID: 661642760}
   - component: {fileID: 661642759}
   - component: {fileID: 661642758}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: SandboxWallRight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3909,7 +3917,7 @@ GameObject:
   - component: {fileID: 678913496}
   - component: {fileID: 678913495}
   - component: {fileID: 678913494}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4113,6 +4121,10 @@ Prefab:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: cb29bea6bc07a4758a457773022a511c, type: 2}
+    - target: {fileID: 1474198792300102, guid: ab395fc603590412fb82c8b7d65d671f, type: 2}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: ab395fc603590412fb82c8b7d65d671f, type: 2}
   m_IsPrefabParent: 0
@@ -4484,7 +4496,7 @@ GameObject:
   - component: {fileID: 784712959}
   - component: {fileID: 784712958}
   - component: {fileID: 784712957}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4657,7 +4669,7 @@ GameObject:
   - component: {fileID: 802458665}
   - component: {fileID: 802458664}
   - component: {fileID: 802458663}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5021,7 +5033,7 @@ GameObject:
   - component: {fileID: 879251766}
   - component: {fileID: 879251765}
   - component: {fileID: 879251764}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5175,7 +5187,7 @@ GameObject:
   - component: {fileID: 900334638}
   - component: {fileID: 900334637}
   - component: {fileID: 900334636}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5326,7 +5338,7 @@ GameObject:
   - component: {fileID: 904491310}
   - component: {fileID: 904491309}
   - component: {fileID: 904491308}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBenchOuter
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5495,6 +5507,10 @@ Prefab:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: cb29bea6bc07a4758a457773022a511c, type: 2}
+    - target: {fileID: 1605301185876994, guid: 5cff69b3316174a9eb19d976d6179107, type: 2}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 5cff69b3316174a9eb19d976d6179107, type: 2}
   m_IsPrefabParent: 0
@@ -5730,7 +5746,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 945393585}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicTable
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6569,7 +6585,7 @@ GameObject:
   - component: {fileID: 1125954050}
   - component: {fileID: 1125954049}
   - component: {fileID: 1125954048}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicTableTop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6669,7 +6685,7 @@ GameObject:
   - component: {fileID: 1132351363}
   - component: {fileID: 1132351362}
   - component: {fileID: 1132351361}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBenchInner
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6963,7 +6979,7 @@ GameObject:
   - component: {fileID: 1225282619}
   - component: {fileID: 1225282618}
   - component: {fileID: 1225282622}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicTableTop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7618,6 +7634,10 @@ Prefab:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: cb29bea6bc07a4758a457773022a511c, type: 2}
+    - target: {fileID: 1506420362013032, guid: b26e861c530fe41d7969e79e0aa2ac1e, type: 2}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b26e861c530fe41d7969e79e0aa2ac1e, type: 2}
   m_IsPrefabParent: 0
@@ -7854,6 +7874,10 @@ Prefab:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: cb29bea6bc07a4758a457773022a511c, type: 2}
+    - target: {fileID: 1506420362013032, guid: b26e861c530fe41d7969e79e0aa2ac1e, type: 2}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b26e861c530fe41d7969e79e0aa2ac1e, type: 2}
   m_IsPrefabParent: 0
@@ -8337,6 +8361,10 @@ Prefab:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: cb29bea6bc07a4758a457773022a511c, type: 2}
+    - target: {fileID: 1730922616687608, guid: 166e5cc180f7f4238a88865970867728, type: 2}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 166e5cc180f7f4238a88865970867728, type: 2}
   m_IsPrefabParent: 0
@@ -8632,7 +8660,7 @@ GameObject:
   - component: {fileID: 1522716036}
   - component: {fileID: 1522716035}
   - component: {fileID: 1522716039}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBenchInner
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8802,7 +8830,7 @@ GameObject:
   - component: {fileID: 1530195936}
   - component: {fileID: 1530195938}
   - component: {fileID: 1530195937}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: sand
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8975,6 +9003,10 @@ Prefab:
     - target: {fileID: 478986, guid: 270831b068c0a074f89e316bd92372a4, type: 2}
       propertyPath: m_LocalScale.z
       value: 7.7198424
+      objectReference: {fileID: 0}
+    - target: {fileID: 129970, guid: 270831b068c0a074f89e316bd92372a4, type: 2}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 270831b068c0a074f89e316bd92372a4, type: 2}
@@ -9321,7 +9353,7 @@ GameObject:
   - component: {fileID: 1613726070}
   - component: {fileID: 1613726069}
   - component: {fileID: 1613726068}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: SandboxWallTop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9614,7 +9646,7 @@ GameObject:
   - component: {fileID: 1631662584}
   - component: {fileID: 1631662583}
   - component: {fileID: 1631662582}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: SandboxWallLeft
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9907,7 +9939,7 @@ GameObject:
   - component: {fileID: 1711193989}
   - component: {fileID: 1711193988}
   - component: {fileID: 1711193987}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10415,7 +10447,7 @@ GameObject:
   - component: {fileID: 1796057530}
   - component: {fileID: 1796057529}
   - component: {fileID: 1796057528}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: SandboxWallBottom
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10956,6 +10988,34 @@ Prefab:
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 100004, guid: 1ffcc181b20fc4b978b455bbf500aacf, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 1ffcc181b20fc4b978b455bbf500aacf, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 100006, guid: 1ffcc181b20fc4b978b455bbf500aacf, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 100008, guid: 1ffcc181b20fc4b978b455bbf500aacf, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 100002, guid: 1ffcc181b20fc4b978b455bbf500aacf, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 100014, guid: 1ffcc181b20fc4b978b455bbf500aacf, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 100012, guid: 1ffcc181b20fc4b978b455bbf500aacf, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 1ffcc181b20fc4b978b455bbf500aacf, type: 3}
   m_IsPrefabParent: 0
@@ -10978,7 +11038,7 @@ GameObject:
   - component: {fileID: 1876832739}
   - component: {fileID: 1876832738}
   - component: {fileID: 1876832737}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11103,7 +11163,7 @@ GameObject:
   - component: {fileID: 1894283470}
   - component: {fileID: 1894283469}
   - component: {fileID: 1894283468}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11463,7 +11523,7 @@ GameObject:
   - component: {fileID: 1940225098}
   - component: {fileID: 1940225097}
   - component: {fileID: 1940225096}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBoard (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11677,6 +11737,10 @@ Prefab:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: cb29bea6bc07a4758a457773022a511c, type: 2}
+    - target: {fileID: 1730922616687608, guid: 166e5cc180f7f4238a88865970867728, type: 2}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 166e5cc180f7f4238a88865970867728, type: 2}
   m_IsPrefabParent: 0
@@ -11796,6 +11860,10 @@ Prefab:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: cb29bea6bc07a4758a457773022a511c, type: 2}
+    - target: {fileID: 1506420362013032, guid: b26e861c530fe41d7969e79e0aa2ac1e, type: 2}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b26e861c530fe41d7969e79e0aa2ac1e, type: 2}
   m_IsPrefabParent: 0
@@ -11963,7 +12031,7 @@ GameObject:
   - component: {fileID: 1995834309}
   - component: {fileID: 1995834308}
   - component: {fileID: 1995834312}
-  m_Layer: 0
+  m_Layer: 13
   m_Name: PicnicBenchOuter
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -12117,6 +12185,22 @@ Prefab:
     - target: {fileID: 400004, guid: f95f35fb0a2694595803bad036eb4320, type: 3}
       propertyPath: m_LocalScale.z
       value: 0.077198446
+      objectReference: {fileID: 0}
+    - target: {fileID: 100008, guid: f95f35fb0a2694595803bad036eb4320, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 100012, guid: f95f35fb0a2694595803bad036eb4320, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 100004, guid: f95f35fb0a2694595803bad036eb4320, type: 3}
+      propertyPath: m_Layer
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 100018, guid: f95f35fb0a2694595803bad036eb4320, type: 3}
+      propertyPath: m_Layer
+      value: 13
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f95f35fb0a2694595803bad036eb4320, type: 3}

--- a/Assets/_Scenes/Menu.unity
+++ b/Assets/_Scenes/Menu.unity
@@ -10742,7 +10742,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1944000889}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d2a971142497c438a887c90bb15b879e, type: 3}
   m_Name: 
@@ -10785,18 +10785,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1944000893}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1783621191}
-        m_MethodName: quitGame
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
 --- !u!114 &1944000893
@@ -11111,8 +11100,8 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 134647873}
-        m_MethodName: setNumberOfPlayers
+      - m_Target: {fileID: 134647872}
+        m_MethodName: 
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/_Scripts/ButterflyCollision.cs
+++ b/Assets/_Scripts/ButterflyCollision.cs
@@ -27,7 +27,7 @@ public class ButterflyCollision : MonoBehaviour {
 //		print ("warningMsgName = " + warningMsgName);
 
 		UICanvas = GameObject.FindGameObjectWithTag("Overlay Canvas");
-		print ("UICanvas = " + UICanvas);
+//		print ("UICanvas = " + UICanvas);
 		switch (GlobalController.numberOfPlayers) {
 		case 2:
 //			print ("Find Warning Message = " + UICanvas.transform.GetChild (0).transform.Find (warningMsgName));

--- a/Assets/_Scripts/DontGoThroughThings.cs
+++ b/Assets/_Scripts/DontGoThroughThings.cs
@@ -46,6 +46,7 @@ public class DontGoThroughThings : MonoBehaviour
 					return;
 
 				if (!hitInfo.collider.isTrigger) {
+					print ("Detected imminent collision in next movement step. Collision with " + hitInfo.collider.name);
 					myRigidbody.position = hitInfo.point - (movementThisStep / movementMagnitude) * partialExtent; 
 					myRigidbody.GetComponent<ButterflyControlsv031> ().movementSpeed = new Vector3 (0.0f, 1.0f, 0.0f);
 				}

--- a/Assets/_Scripts/DontGoThroughThings.cs
+++ b/Assets/_Scripts/DontGoThroughThings.cs
@@ -46,7 +46,6 @@ public class DontGoThroughThings : MonoBehaviour
 					return;
 
 				if (!hitInfo.collider.isTrigger) {
-					print ("Detected imminent collision in next movement step. Collision with " + hitInfo.collider.name);
 					myRigidbody.position = hitInfo.point - (movementThisStep / movementMagnitude) * partialExtent; 
 					myRigidbody.GetComponent<ButterflyControlsv031> ().movementSpeed = new Vector3 (0.0f, 1.0f, 0.0f);
 				}

--- a/Assets/_Scripts/GameController.cs
+++ b/Assets/_Scripts/GameController.cs
@@ -102,9 +102,9 @@ public class GameController: MonoBehaviour {
 		MainMenuButton = UICanvas.transform.Find ("Main Menu Button").gameObject;
 		PlayAgainButton = UICanvas.transform.Find ("Play Again Button").gameObject;
 		RestartGameButton = UICanvas.transform.Find ("Restart Button").gameObject;
-		MainMenuButton.GetComponent<Button> ().onClick.AddListener(() => GlobalController.mainMenu());
-		RestartGameButton.GetComponent<Button> ().onClick.AddListener(() => GlobalController.startGame());
-		PlayAgainButton.GetComponent<Button> ().onClick.AddListener(() => GlobalController.startGame());
+		MainMenuButton.GetComponent<Button> ().onClick.AddListener(() => GlobalController.MainMenu());
+		RestartGameButton.GetComponent<Button> ().onClick.AddListener(() => GlobalController.StartGame());
+		PlayAgainButton.GetComponent<Button> ().onClick.AddListener(() => GlobalController.StartGame());
 	}
 
 	// Set current state and last state change time

--- a/Assets/_Scripts/GlobalController.cs
+++ b/Assets/_Scripts/GlobalController.cs
@@ -20,18 +20,22 @@ public class GlobalController : MonoBehaviour {
 		DontDestroyOnLoad (gameObject);
 	}
 
-	public static void startGame() {
-		print ("Game Start!");
+	public static void StartGame() {
 		SceneManager.LoadScene ("BKFstage");
 	}
 
-	public static void mainMenu() {
-		print ("Main Menu");
+	public static void MainMenu() {
 		SceneManager.LoadScene ("Menu");
 	}
 
-	public void quitGame() {
-		print ("Quitting game...");
-		Application.Quit ();
+	public static void QuitGame()
+	{
+		#if UNITY_EDITOR
+		// Application.Quit() does not work in the editor so
+		// UnityEditor.EditorApplication.isPlaying need to be set to false to end the game
+		UnityEditor.EditorApplication.isPlaying = false;
+		#else
+		Application.Quit();
+		#endif
 	}
 }

--- a/Assets/_Scripts/QuitButton.cs
+++ b/Assets/_Scripts/QuitButton.cs
@@ -8,7 +8,7 @@ public class QuitButton : MonoBehaviour {
 	// Use this for initialization
 	void Start () {
 		print ("Please quit?");
-		gameObject.GetComponent<Button> ().onClick.AddListener(() => GlobalController.mainMenu());
+		gameObject.GetComponent<Button> ().onClick.AddListener(() => GlobalController.QuitGame());
 	}
 	
 	// Update is called once per frame

--- a/Assets/_Scripts/StartButton.cs
+++ b/Assets/_Scripts/StartButton.cs
@@ -7,7 +7,7 @@ public class StartButton : MonoBehaviour {
 
 	// Use this for initialization
 	void Start () {
-		gameObject.GetComponent<Button> ().onClick.AddListener(() => GlobalController.startGame());
+		gameObject.GetComponent<Button> ().onClick.AddListener(() => GlobalController.StartGame());
 	}
 	
 	// Update is called once per frame

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -28,7 +28,7 @@ TagManager:
   - Player 3
   - Player 4
   - Ground
-  - 
+  - Obstacles
   - 
   - 
   - 


### PR DESCRIPTION
Fixed the ghost collisions that were triggering the "Don't Go Through Things" script to stop the butterflies in mid-air. 

Added clamping to rotation while character is in "is_Landed" status so they cannot rotate upside down. This simultaneously fixed a common complaint among playtesters (confusing angles while on the ground) and a pretty severe bug (passing through the ground by flapping while upside down on the ground). 